### PR TITLE
Added output for invalid file types

### DIFF
--- a/exploits.go
+++ b/exploits.go
@@ -189,9 +189,11 @@ func initCommand(inputFile string, mode string) {
 		fmt.Println("completed task.")
 		os.Remove(out)
 
+	} else if inputFile == "no input file provided" {
+		return
+
 	} else {
-		if inputFile == "no input file provided" {
-			return
-		}
-	}
+        fmt.Println("incompatible input file")
+
+    }
 }

--- a/exploits/crash-video.go
+++ b/exploits/crash-video.go
@@ -22,7 +22,7 @@ func RunCrashVideoTask(filename string) {
 	err = os.WriteFile(binname, bin, 0777)
 	modules.Check(err)
 	modules.CheckForFFmpeg()
-	cmd := exec.Command("ffmpeg", "-f", "concat", "-i", txtname, "-y", "-safe", "0", "-c", "copy", outname)
+	cmd := exec.Command("ffmpeg", "-f", "concat", "-safe", "0", "-i", txtname, "-y", "-c", "copy", outname)
 	err = cmd.Run()
 	modules.Check(err)
 


### PR DESCRIPTION
If a file type wasn't recognised by the program, there would be no message to explain this.